### PR TITLE
Criação da fatos vendas e do teste de vendas em 1997

### DIFF
--- a/models/intermediate/int_vendas__pedido_itens.sql
+++ b/models/intermediate/int_vendas__pedido_itens.sql
@@ -1,0 +1,43 @@
+with
+    stg_ordens as (
+        select *
+        from {{ ref('stg_erp__ordens') }}
+    )
+    , stg_ordem_detalhes as (
+        select *
+        from {{ ref('stg_erp__ordem_detalhes') }}
+    )
+    , joined_tabelas as (
+        select 
+            stg_ordens.id_pedido
+            , stg_ordens.id_funcionario
+            , stg_ordens.id_cliente
+            , stg_ordens.id_transportadora
+            , stg_ordem_detalhes.id_produto
+
+            , stg_ordens.data_do_pedido
+            , stg_ordens.frete
+            , stg_ordens.destinatario
+            , stg_ordens.endereco_destinatario
+            , stg_ordens.cep_destinatario
+            , stg_ordens.cidade_destinatario
+            , stg_ordens.regiao_destinatario
+            , stg_ordens.pais_destinatario
+            , stg_ordens.data_do_envio
+            , stg_ordens.data_requerida_entrega
+            , stg_ordem_detalhes.preco_unitario
+            , stg_ordem_detalhes.quantidade
+            , stg_ordem_detalhes.desconto
+        from stg_ordem_detalhes
+        left join stg_ordens on
+            stg_ordem_detalhes.id_pedido = stg_ordens.id_pedido
+    )
+    , criar_chave as (
+        select
+            cast(id_pedido as string) || '-' || cast(id_produto as string) as sk_pedido_item
+            , *
+        from joined_tabelas
+    )
+
+select *
+from criar_chave

--- a/models/intermediate/int_vendas__pedido_itens.yml
+++ b/models/intermediate/int_vendas__pedido_itens.yml
@@ -1,0 +1,12 @@
+version: 2
+
+models:
+  - name: int_vendas__pedido_itens
+    description: Tabela de vendas intermediária criada a partir da junção entre orders e order_details
+    columns:
+      - name: sk_pedido_item
+        description: Chave surrogate da tabela pedido itens
+        tests:
+          - unique
+          - not_null
+          

--- a/models/marts/dim_funcionarios.sql
+++ b/models/marts/dim_funcionarios.sql
@@ -1,0 +1,35 @@
+with
+    stg_funcionario as (
+        select 
+            id_funcionario
+            , id_gerente
+            , nome_funcionario
+            , cargo_funcionario
+            , dt_nascimento_funcionario
+            , dt_contratacao
+            , cidade_funcionario
+            , regiao_funcionario
+            , pais_funcionario
+            , informacoes_funcionario
+        from {{ ref('stg_erp__funcionarios') }}
+    )
+    , self_joined as (
+        select 
+            funcionario.id_funcionario
+            , funcionario.id_gerente
+            , funcionario.nome_funcionario
+            , gerente.nome_funcionario as nome_gerente
+            , funcionario.cargo_funcionario
+            , funcionario.dt_nascimento_funcionario
+            , funcionario.dt_contratacao
+            , funcionario.cidade_funcionario
+            , funcionario.regiao_funcionario
+            , funcionario.pais_funcionario
+            , funcionario.informacoes_funcionario
+        from stg_funcionario as funcionario
+            left join stg_funcionario as gerente on
+            funcionario.id_gerente = gerente.id_funcionario
+            
+    )
+select *
+from self_joined

--- a/models/marts/dim_funcionarios.yml
+++ b/models/marts/dim_funcionarios.yml
@@ -1,0 +1,42 @@
+version: 2
+
+models:
+  - name: dim_funcionarios
+    description: Dimensão de funcionários da Northwind. Relação de funcionários e gerentes e dados dos funcionários.
+    columns:
+      - name: id_funcionario
+        description: preencher
+        tests:
+          - unique
+          - not_null
+
+      - name: id_gerente
+        description: preencher
+
+      - name: nome_funcionario
+        description: preencher
+
+      - name: nome_funcionario_1
+        description: preencher
+
+      - name: cargo_funcionario
+        description: preencher
+
+      - name: dt_nascimento_funcionario
+        description: preencher
+
+      - name: dt_contratacao
+        description: preencher
+
+      - name: cidade_funcionario
+        description: preencher
+
+      - name: regiao_funcionario
+        description: preencher
+
+      - name: pais_funcionario
+        description: preencher
+
+      - name: informacoes_funcionario
+        description: preencher
+

--- a/models/marts/fct_vendas.sql
+++ b/models/marts/fct_vendas.sql
@@ -1,0 +1,117 @@
+with
+    funcionarios as (
+        select *
+        from {{ ref('dim_funcionarios') }}
+    )
+    , produtos as (
+        select *
+        from {{ ref('dim_produtos') }}
+    )
+    , int_vendas as (
+        select *
+        from {{ ref('int_vendas__pedido_itens') }}
+    )
+    , joined_tabelas as (
+        select 
+            --CHAVES--
+            sk_pedido_item
+            , int_vendas.id_pedido
+            , int_vendas.id_funcionario
+            , int_vendas.id_cliente
+            , int_vendas.id_transportadora
+            , int_vendas.id_produto
+            
+            --DATAS--
+            , int_vendas.data_do_pedido
+            , int_vendas.data_do_envio
+            , int_vendas.data_requerida_entrega
+
+            --MÉTRICAS--
+            , int_vendas.preco_unitario
+            , int_vendas.quantidade
+            , int_vendas.desconto
+            , int_vendas.frete
+
+            --CATEGORIAS (para agrupar as métricas)--
+            , int_vendas.destinatario
+            , int_vendas.endereco_destinatario
+            , int_vendas.cep_destinatario
+            , int_vendas.cidade_destinatario
+            , int_vendas.regiao_destinatario
+            , int_vendas.pais_destinatario
+            
+            , produtos.nome_produto
+            , produtos.eh_descontinuado
+            , produtos.nome_categoria
+            , produtos.nome_fornecedor
+            , produtos.pais_fornecedor
+
+            , funcionarios.nome_funcionario
+            , funcionarios.nome_gerente
+            , funcionarios.cargo_funcionario
+            , funcionarios.dt_nascimento_funcionario
+            , funcionarios.dt_contratacao
+        from int_vendas
+        left join produtos on
+            int_vendas.id_produto = produtos.id_produto
+        left join funcionarios on
+            int_vendas.id_funcionario = funcionarios.id_funcionario
+    )
+    , transformacoes as (
+        select 
+        *
+        , quantidade * preco_unitario as total_bruto
+        , quantidade * preco_unitario * (1 - desconto) as total_liquido
+        , case
+            when desconto > 0 then 'Sim'
+            else 'Nao'
+        end as teve_desconto
+        , frete / count(id_pedido) over (partition by id_pedido) as frete_ponderado
+        from joined_tabelas
+    )
+    , select_final as (
+        select
+            --Chaves
+            sk_pedido_item
+            , id_pedido
+            , id_funcionario
+            , id_cliente
+            , id_transportadora
+            , id_produto
+
+            --Datas
+            , data_do_pedido
+            , data_do_envio
+            , data_requerida_entrega
+
+            --Métricas
+            , preco_unitario
+            , quantidade
+            , desconto
+            , total_bruto
+            , total_liquido
+            , teve_desconto
+            , frete_ponderado            
+
+            --Categorias (para agrupar as métricas)
+            , destinatario
+            , endereco_destinatario
+            , cep_destinatario
+            , cidade_destinatario
+            , regiao_destinatario
+            , pais_destinatario
+            , nome_produto
+            , eh_descontinuado
+            , nome_categoria
+            , nome_fornecedor
+            , pais_fornecedor
+            , nome_funcionario
+            , nome_gerente
+            , cargo_funcionario
+            , dt_nascimento_funcionario
+            , dt_contratacao
+
+        from transformacoes
+    )
+select *
+from select_final

--- a/models/marts/fct_vendas.yml
+++ b/models/marts/fct_vendas.yml
@@ -1,0 +1,19 @@
+version: 2
+
+models:
+  - name: fct_vendas
+    description: Tabela de vendas onde cada linha representa a venda de um produto.
+    columns:
+      - name: sk_pedido_itens
+        description: Chave surrogada concatenando o número do pedido com o produto vendido.
+        tests:
+          - not_null
+          - unique
+          
+      - name: frete_ponderado
+        description: Métrica criada dividindo o frete pelo número de produtos diferentes naquela nota fiscal.
+
+      - name: total_bruto
+        description: Quantidade vendida do produto multiplicada pelo preço sem desconto
+      - name: total_liquido
+        description: Quantidade vendida do produto multiplicada pelo preço com desconto

--- a/models/staging/erp_northwind/sources.yml
+++ b/models/staging/erp_northwind/sources.yml
@@ -5,11 +5,20 @@ sources:
     description: Fonte SAP de vendas da Northwind
     schema: erp_northwind
     tables:
-    - name: products
-      columns:
-        - name: product_id
-          tests:
-            - unique
-            - not_null
-    - name: categories
-    - name: suppliers
+      - name: products
+        columns:
+          - name: product_id
+            tests:
+              - unique
+              - not_null
+      - name: categories
+      - name: suppliers
+      - name: employees
+      - name: orders
+        description: Tabela de pedidos onde só podemos ter uma nota fiscal por linha, sendo não nula.
+        columns:
+          - name: order_id
+            tests:
+              - unique
+              - not_null
+      - name: order_details

--- a/models/staging/erp_northwind/stg_erp__funcionarios.sql
+++ b/models/staging/erp_northwind/stg_erp__funcionarios.sql
@@ -1,0 +1,18 @@
+with
+    fonte_funcionarios as (
+        select 
+            cast(employee_id as int) as id_funcionario
+            , cast(reports_to as int) as id_gerente
+            , cast(first_name as string) || ' ' || cast(last_name as string) as nome_funcionario
+            , cast(title as string) as cargo_funcionario
+            , cast(birth_date as date) as dt_nascimento_funcionario
+            , cast(hire_date as date) as dt_contratacao
+            , cast(city as string) as cidade_funcionario
+            , cast(region as string) as regiao_funcionario
+            , cast(country as string) as pais_funcionario
+            , cast(notes as string) as informacoes_funcionario
+            
+        from {{ source('erp', 'employees') }}
+    )
+select *
+from fonte_funcionarios

--- a/models/staging/erp_northwind/stg_erp__ordem_detalhes.sql
+++ b/models/staging/erp_northwind/stg_erp__ordem_detalhes.sql
@@ -1,0 +1,12 @@
+with
+    fonte_ordem_detalhes as (
+        select 
+            cast(order_id as int) as id_pedido
+            , cast(product_id as int) as id_produto
+            , cast(unit_price as numeric) as preco_unitario
+            , cast(quantity as int) as quantidade
+            , cast(discount as numeric) as desconto
+        from {{ source('erp', 'order_details') }}
+    )
+select *
+from fonte_ordem_detalhes

--- a/models/staging/erp_northwind/stg_erp__ordens.sql
+++ b/models/staging/erp_northwind/stg_erp__ordens.sql
@@ -1,0 +1,21 @@
+with
+    fonte_ordens as (
+        select 
+            cast(order_id as int) as id_pedido
+            , cast(employee_id as int) as id_funcionario
+            , cast(customer_id as string) as id_cliente
+            , cast(ship_via as int) as id_transportadora
+            , cast(order_date as date) as data_do_pedido
+            , cast(freight as numeric) as frete
+            , cast(ship_name as string) as destinatario
+            , cast(ship_address as string) as endereco_destinatario
+            , cast(ship_postal_code as string) as cep_destinatario
+            , cast(ship_city as string) as cidade_destinatario
+            , cast(ship_region as string) as regiao_destinatario
+            , cast(ship_country as string) as pais_destinatario
+            , cast(shipped_date as date) as data_do_envio 
+            , cast(required_date as date) as data_requerida_entrega
+        from {{ source('erp', 'orders') }}
+    )
+select *
+from fonte_ordens

--- a/tests/total_vendido_1997.sql
+++ b/tests/total_vendido_1997.sql
@@ -1,0 +1,10 @@
+/* O time comercial tem validado que as vendas realizadas em 1997 somam $ 658,388.75 */
+with
+    vendas_em_1997 as (
+        select sum(total_bruto) as total_bruto_vendido
+        from {{ ref('fct_vendas') }}
+        where data_do_pedido between '1997-01-01' and '1997-12-31'
+    )
+select total_bruto_vendido
+from vendas_em_1997
+where total_bruto_vendido not between 658388 and 658389


### PR DESCRIPTION
A tabela fatos vendas foi criada juntando as tabelas order, order_details (int_vendas), dim_funcionarios e dim_produtos.
Foram selecionadas as colunas pertinentes para o negócio e foram criadas mais algumas (total bruto, total líquido e frete ponderado).
Foi criado o teste de vendas brutas totais em 1997 para garantir a consistência dos dados.